### PR TITLE
Support redis 6 ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # py_check_redis
+
+
+Add redis user with these permissions:
+```
+-@all +info +ping
+```
+
+Plugin checks backup nodes automatically for being readonly and connection to master, ie:
+```
+master_link_status:up
+slave_read_only:1
+```
+
+Number of expected replicas on a master is configurable, ie:
+```
+check_redis.py -u monitoring -P $(/usr/bin/cat /etc/check_redis_auth) --backup_nodes=1
+```
+
+Or omit the ```--backup_nodes``` flag for a standalone/single instance.

--- a/check_redis.py
+++ b/check_redis.py
@@ -8,14 +8,15 @@ from optparse import OptionParser
 
 class NagiosRedis(object):
 
-    def __init__(self, host, port, password, bdname):
+    def __init__(self, host, port, username, password, dbname):
         self.host = host
+        self.username = username
         self.password = password
         self.port = port
-        self.dbname = bdname
+        self.dbname = dbname
 
         try:
-            self.conn = redis.Redis(host=self.host, port=self.port, password=self.password, socket_timeout=1)
+            self.conn = redis.Redis(host=self.host, port=self.port, username=self.username, password=self.password, socket_timeout=1)
             self.info_out = self.conn.info()
             self.conn.ping()
 
@@ -65,8 +66,9 @@ def build_parser():
     :return: parser config
     """
     parser = OptionParser(usage="usage: %prog [options]", version="%prog 1.0")
-    parser.add_option("-H", "--host", dest="host", help="Redis server to connect to.", default=False)
+    parser.add_option("-H", "--host", dest="host", help="Redis server to connect to.", default='127.0.0.1')
     parser.add_option("-p", "--port", dest="port", help="Redis port to connect to.", type="int", default=6379)
+    parser.add_option("-u", "--username", dest="username", help="Redis username.",  default='default')
     parser.add_option("-P", "--password", dest="password", help="Redis password to connect to.",  default='')
     parser.add_option("-d", "--dbname", dest="dbname", help="Redis database name, default is db0", default='db0')
     parser.add_option("-t", "--timeout", dest="timeout",
@@ -85,5 +87,5 @@ if __name__ == "__main__":
         sys.exit(0)
 
     else:
-        server = NagiosRedis(options.host, options.port, options.password, options.dbname)
+        server = NagiosRedis(options.host, options.port, options.username, options.password, options.dbname)
         server.nagios_check()

--- a/check_redis.py
+++ b/check_redis.py
@@ -3,17 +3,19 @@
 
 import redis
 import sys
+import re
 from optparse import OptionParser
 
 
 class NagiosRedis(object):
 
-    def __init__(self, host, port, username, password, dbname):
+    def __init__(self, host, port, username, password, dbname, backup_nodes):
         self.host = host
         self.username = username
         self.password = password
         self.port = port
         self.dbname = dbname
+        self.backup_nodes = backup_nodes
 
         try:
             self.conn = redis.Redis(host=self.host, port=self.port, username=self.username, password=self.password, socket_timeout=1)
@@ -44,6 +46,26 @@ class NagiosRedis(object):
 
         return "used_memory_human: %s" % self.info_out['used_memory_human']
 
+    def get_role(self):
+
+        return "role: %s" % self.info_out['role']
+
+    def get_connected_backups(self):
+
+        return "connected_backups: %s" % self.info_out['connected_slaves']
+
+    def get_mls(self):
+
+        return "master_link_status: %s" % self.info_out['master_link_status']
+
+    def get_ro(self):
+
+        return "slave_read_only: %s" % self.info_out['slave_read_only']
+
+    def get_master(self):
+
+        return "master_host: %s" % self.info_out['master_host']
+
     def nagios_check(self):
         number_keys = ''
         version = self.get_version()
@@ -52,11 +74,26 @@ class NagiosRedis(object):
             number_keys = self.get_number_keys()
         memory = self.get_used_memory()
         uptime = self.get_uptime()
+        role = self.get_role()
+        replicas = self.get_connected_backups()
+        replica_count = int(re.sub('\D', '', replicas))
+        backup_nodes = int(self.backup_nodes)
+        if 'master' in role:
+            if replica_count != backup_nodes:
+                print('REDIS CRITICAL - %s, %s' % (replicas, role))
+                sys.exit(2)
+        if 'slave' in role:
+            mls = self.get_mls()
+            ro = self.get_ro()
+            master = self.get_master()
+            if 'up' not in mls or '1' not in ro:
+                print('REDIS CRITICAL - %s, %s, %s, %s' % (role, mls, ro, master))
+                sys.exit(2)
         if number_keys == '':
-            print('OK REDIS No keys, %s, %s, %s' % (version, memory, uptime))
+            print('OK REDIS No keys, %s, %s, %s, %s' % (version, memory, uptime, role))
             sys.exit(0)
         else:
-            print('OK REDIS %s, %s, %s, %s, %s' % (version, client_connected, number_keys, memory, uptime))
+            print('OK REDIS %s, %s, %s, %s, %s, %s' % (version, client_connected, number_keys, memory, uptime, role))
             sys.exit(0)
 
 
@@ -71,6 +108,7 @@ def build_parser():
     parser.add_option("-u", "--username", dest="username", help="Redis username.",  default='default')
     parser.add_option("-P", "--password", dest="password", help="Redis password to connect to.",  default='')
     parser.add_option("-d", "--dbname", dest="dbname", help="Redis database name, default is db0", default='db0')
+    parser.add_option("-b", "--backup_nodes", dest="backup_nodes", help="Number of connected backup nodes to check for",  default=0)
     parser.add_option("-t", "--timeout", dest="timeout",
                       help="Number of milliesconds to wait before timing out and considering redis down",
                       type="int", default=2000)
@@ -87,5 +125,5 @@ if __name__ == "__main__":
         sys.exit(0)
 
     else:
-        server = NagiosRedis(options.host, options.port, options.username, options.password, options.dbname)
+        server = NagiosRedis(options.host, options.port, options.username, options.password, options.dbname, options.backup_nodes)
         server.nagios_check()


### PR DESCRIPTION
Make ACLs work with redis 6, should support the default user for <6 versions:

> In the default configuration, Redis 6 (the first version to have ACLs) works exactly like older versions of Redis, that is, every new connection is capable of calling every possible command and accessing every key, so the ACL feature is backward compatible with old clients and applications. Also the old way to configure a password, using the requirepass configuration directive, still works as expected, but now what it does is just to set a password for the default user.